### PR TITLE
Library description in the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Store your tokens in a text file whose name matches this pattern.
-*tokens*
+*token*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -6,15 +6,7 @@ Cette bibliothèque aide à obtenir les données des commits d'un dépôt au moy
 de l'API de GitHub. L'utilisateur doit fournir ses informations
 d'authentification.
 
-Exécutez cette commande pour installer les dépendances.
-
-```
-pip install -r requirements.txt
-```
-
-`commitfetch` contient les classes et fonctions suivantes. Consultez les
-scripts `demo_write_commits.py` et `demo_read_commits.py` pour savoir comment
-les utiliser.
+### Contenu
 
 **`Commit`**
 
@@ -24,7 +16,7 @@ Cette classe contient des données extraites d'un commit de GitHub.
 
 Cette classe contient le nom d'un utilisateur de GitHub et des jetons
 d'authentification qu'il possède. Elle aide à effectuer des requêtes
-authentifiées à l'API de GitHub.
+authentifiées à l'API de GitHub. Chaque jeton permet 2000 requêtes par heure.
 
 **`RepoIdentity`**
 
@@ -58,19 +50,56 @@ Les représetations sont des chaînes de caractères renvoyées par la fonction
 `repr`. Chaque ligne du fichier contient une représentation. La fonction
 `read_reprs` peut lire ce fichier.
 
-# English
+### Démos
 
-This library helps obtaining the data of a repository's commits through the
-GitHub API. Authentication with GitHub credentials is required.
-
-Execute this command to install the dependecies.
+Exécutez cette commande pour installer les dépendances.
 
 ```
 pip install -r requirements.txt
 ```
 
-`commitfetch` contains the following classes and functions. See scripts
-`demo_write_commits.py` and `demo_read_commits.py` to know how to use them.
+Consultez les scripts `demo_write_commits.py` et `demo_read_commits.py` dans le
+dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
+
+`demo_write_commits.py` obtient les commits d'un dépôt GitHub et enregistre
+leur représentation dans un fichier texte. Il a besoin d'un fichier listant les
+jetons d'authentification de l'utilisateur pour effectuer des requêtes à l'API
+GitHub. Pour que ce dépôt ignore les fichiers de jetons, leur nom devrait
+contenir la chaîne «token».
+
+Exemple d'exécution:
+
+```
+python demo_write_commits.py -u GRV96 -t tokens.txt -r scottyab/rootbeer
+```
+
+Pour essayer `demo_write_commits.py` avec des nombres de commits variés,
+utilisez les dépôts ci-dessous.
+
+| Dépôt                     | Nombre de commits |
+|---------------------------|:-----------------:|
+| k9mail/k-9                | 10 985            |
+| Skyscanner/backpack       | 7075              |
+| mendhak/gpslogger         | 2239              |
+| PeterIJia/android_xlight  | 397               |
+| scottyab/rootbeer         | 191               |
+
+`demo_read_commits.py` montre comment lire les représentations de commits
+enregistrées par `demo_write_commits.py`. Pour confirmer que la lecture a
+fonctionné, il affiche les données d'un commit dans la console.
+
+Exemple d'exécution:
+
+```
+python demo_read_commits.py -c scottyab_rootbeer_commits.txt
+```
+
+# English
+
+This library helps obtaining the data of a repository's commits through the
+GitHub API. Authentication with GitHub credentials is required.
+
+### Content
 
 **`Commit`**
 
@@ -79,7 +108,8 @@ This class contains data extracted from a GitHub commit.
 **`GitHubCredentials`**
 
 This class contains the name of a GitHub user and authentication tokens that
-they own. It helps making authenticated requests to the GitHub API.
+they own. It helps making authenticated requests to the GitHub API. Each token
+allows 2000 requests per hour.
 
 **`RepoIdentity`**
 
@@ -109,3 +139,45 @@ must contain one representation.
 This function writes the representations of Python objects in a text file. The
 representations are strings returned by function `repr`. Each line of the file
 contains one representation. Function `read_reprs` can read this file.
+
+### Demos
+
+Execute this command to install the dependecies.
+
+```
+pip install -r requirements.txt
+```
+
+See scripts `demo_write_commits.py` and `demo_read_commits.py` in the source
+code repository to know how to use library `commitfetch`.
+
+`demo_write_commits.py` obtains a GitHub repository's commits and writes their
+representation in a text file. It needs a file that lists the user's
+authentication tokens to perform requests to the GitHub API. This repository
+will ignore the token files if their name contains the string "token".
+
+Execution example:
+
+```
+python demo_write_commits.py -u GRV96 -t tokens.txt -r scottyab/rootbeer
+```
+To try `demo_write_commits.py` with varied numbers of commits, use the
+repositories below.
+
+| Repository                | Number of commits |
+|---------------------------|:-----------------:|
+| k9mail/k-9                | 10 985            |
+| Skyscanner/backpack       | 7075              |
+| mendhak/gpslogger         | 2239              |
+| PeterIJia/android_xlight  | 397               |
+| scottyab/rootbeer         | 191               |
+
+`demo_read_commits.py` shows how to read the commit representations recorded by
+`demo_write_commits.py`. It confirms that the reading was successful by
+displaying a commit's data in the console.
+
+Execution example:
+
+```
+python demo_read_commits.py -c scottyab_rootbeer_commits.txt
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ fichier texte, un par ligne.
 Cette fonction est l'élément principal de `commitfetch`. C'est elle qui
 effectue les requêtes à l'API de GitHub pour obtenir les données des commits
 d'un dépôt. Il faut lui fournir des informations d'authentification dans une
-instance de `GitHubCredentials`.
+instance de `GitHubCredentials`. La fonction `get_repo_commits` est inspirée de
+la fonction `countfiles` du script
+[CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
 
 **`read_reprs`**
 
@@ -125,7 +127,9 @@ allows for example to access tokens stored in a text file, one per line.
 
 This function is the main element of `commitfetch`. It performs requests to the
 GitHub API to obtain data about a repository's commits. The user must provide
-their credentials in a `GitHubCredentials` instance.
+their credentials in a `GitHubCredentials` instance. Function
+`get_repo_commits` is based on function `countfiles` from script
+[CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
 
 **`read_reprs`**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,110 @@
 # commitfetch
 
+## Français
+
+Cette bibliothèque aide à obtenir les données des commits d'un dépôt au moyen
+de l'API de GitHub. L'utilisateur doit fournir ses informations
+d'authentification.
+
+Exécutez cette commande pour installer les dépendances.
+
+```
+pip install -r requirements.txt
+```
+
+`commitfetch` contient les classes et fonctions suivantes. Consultez les
+scripts `demo_write_commits.py` et `demo_read_commits.py` pour savoir comment
+les utiliser.
+
+**`Commit`**
+
+Cette classe contient des données extraites d'un commit de GitHub.
+
+**`GitHubCredentials`**
+
+Cette classe contient le nom d'un utilisateur de GitHub et des jetons
+d'authentification qu'il possède.
+
+**`RepoIdentity`**
+
+Cette classe identifie un dépôt GitHub par le nom de son propriétaire et le nom
+du dépôt. L'identité est souvent écrite sous le format `propriétaire`/`nom`.
+
+**`extract_text_lines`**
+
+Cette fonction lit le fichier texte spécifié et renvoie ses lignes dans une
+liste. Elle permet par exemple d'accéder à des jetons enregistrés dans un
+fichier texte.
+
+**`get_repo_commits`**
+
+Cette fonction est l'élément principal de `commitfetch`. C'est elle qui
+effectue les requêtes à l'API de GitHub pour obtenir les données des commits
+d'un dépôt. Il faut lui fournir des informations d'authentification dans une
+instance de `GitHubCredentials`.
+
+**`read_reprs`**
+
+Cette fonction lit un fichier texte contenant les représentations d'objets
+Python puis recrée ces objets et les renvoie dans une liste. Les représetations
+sont des chaînes de caractères renvoyées par la fonction `repr`. Chaque ligne
+du fichier doit contenir une représentation.
+
+**`write_reprs`**
+
+Cette fonction écrit les représentations d'objets Python dans un fichier texte.
+Les représetations sont des chaînes de caractères renvoyées par la fonction
+`repr`. Chaque ligne du fichier contient une représentation. La fonction
+`read_reprs` peut lire ce fichier.
+
+# English
+
 This library helps obtaining the data of a repository's commits through the
 GitHub API. Authentication with GitHub credentials is required.
+
+Execute this command to install the dependecies.
+
+```
+pip install -r requirements.txt
+```
+
+`commitfetch` contains the following classes and functions. See scripts
+`demo_write_commits.py` and `demo_read_commits.py` to know how to use them.
+
+**`Commit`**
+
+This class contains data extracted from a GitHub commit.
+
+**`GitHubCredentials`**
+
+This class contains the name of a GitHub user and authentication tokens that
+they own.
+
+**`RepoIdentity`**
+
+This class identifies a GitHub repository by its owner's name and the
+repository's name. The identity is often written in the format `owner`/`name`.
+
+**`extract_text_lines`**
+
+This function reads the specified text file and returns its lines in a list. It
+allows for example to access tokens stored in a text file.
+
+**`get_repo_commits`**
+
+This function is the main element of `commitfetch`. It performs requests to the
+GitHub API to obtain data about a repository's commits. The user must provide
+their credentials in a `GitHubCredentials` instance.
+
+**`read_reprs`**
+
+This function reads a text file that contains the representations of Python
+objects then recreates those objects and returns them in a list. The
+representations are strings returned by function `repr`. Each line of the file
+must contain one representation.
+
+**`write_reprs`**
+
+This function writes the representations of Python objects in a text file. The
+representations are strings returned by function `repr`. Each line of the file
+contains one representation. Function `read_reprs` can read this file.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Exemple d'exécution:
 python demo_read_commits.py -c scottyab_rootbeer_commits.txt
 ```
 
-# English
+## English
 
 This library helps obtaining the data of a repository's commits through the
 GitHub API. Authentication with GitHub credentials is required.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ d'authentification.
 
 **`Commit`**
 
-Cette classe contient des données extraites d'un commit de GitHub.
+Cette classe contient des données d'un commit de GitHub.
 
 **`GitHubCredentials`**
 
@@ -103,7 +103,7 @@ GitHub API. Authentication with GitHub credentials is required.
 
 **`Commit`**
 
-This class contains data extracted from a GitHub commit.
+This class contains data of a GitHub commit.
 
 **`GitHubCredentials`**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ du dépôt. L'identité est souvent écrite sous le format `propriétaire`/`nom`
 
 Cette fonction lit le fichier texte spécifié et renvoie ses lignes dans une
 liste. Elle permet par exemple d'accéder à des jetons enregistrés dans un
-fichier texte.
+fichier texte, un par ligne.
 
 **`get_repo_commits`**
 
@@ -63,9 +63,9 @@ dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
 
 `demo_write_commits.py` obtient les commits d'un dépôt GitHub et enregistre
 leur représentation dans un fichier texte. Il a besoin d'un fichier listant les
-jetons d'authentification de l'utilisateur pour effectuer des requêtes à l'API
-GitHub. Pour que ce dépôt ignore les fichiers de jetons, leur nom devrait
-contenir la chaîne «token».
+jetons d'authentification de l'utilisateur un par ligne pour effectuer des
+requêtes à l'API GitHub. Pour que ce dépôt ignore les fichiers de jetons, leur
+nom devrait contenir la chaîne «token».
 
 Exemple d'exécution:
 
@@ -119,7 +119,7 @@ repository's name. The identity is often written in the format `owner`/`name`.
 **`extract_text_lines`**
 
 This function reads the specified text file and returns its lines in a list. It
-allows for example to access tokens stored in a text file.
+allows for example to access tokens stored in a text file, one per line.
 
 **`get_repo_commits`**
 
@@ -153,8 +153,9 @@ code repository to know how to use library `commitfetch`.
 
 `demo_write_commits.py` obtains a GitHub repository's commits and writes their
 representation in a text file. It needs a file that lists the user's
-authentication tokens to perform requests to the GitHub API. This repository
-will ignore the token files if their name contains the string "token".
+authentication tokens one per line to perform requests to the GitHub API. This
+repository will ignore the token files if their name contains the string
+"token".
 
 Execution example:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Cette classe contient des données extraites d'un commit de GitHub.
 **`GitHubCredentials`**
 
 Cette classe contient le nom d'un utilisateur de GitHub et des jetons
-d'authentification qu'il possède.
+d'authentification qu'il possède. Elle aide à effectuer des requêtes
+authentifiées à l'API de GitHub.
 
 **`RepoIdentity`**
 
@@ -78,7 +79,7 @@ This class contains data extracted from a GitHub commit.
 **`GitHubCredentials`**
 
 This class contains the name of a GitHub user and authentication tokens that
-they own.
+they own. It helps making authenticated requests to the GitHub API.
 
 **`RepoIdentity`**
 

--- a/commitfetch/commit.py
+++ b/commitfetch/commit.py
@@ -37,8 +37,8 @@ class Commit:
 				deleted in this commit as strings or pathlib.Path objects
 
 		Raises:
-			ValueError: if argument repository is a string and does not match
-				format <owner>/<name>
+			ValueError: if argument repository or moment is a string and does
+				not match the expected format
 		"""
 		self._sha = sha
 		self._message = message
@@ -157,7 +157,7 @@ class RepoIdentity:
 			RepoIdentity: an object that identifies the indicated repository
 
 		Raises:
-			ValueError: if parameter full_name is not in the right format
+			ValueError: if parameter full_name is not in the expected format
 		"""
 		split_name = full_name.split(_SLASH)
 

--- a/commitfetch/commitfetch.py
+++ b/commitfetch/commitfetch.py
@@ -89,6 +89,9 @@ def get_repo_commits(repository, credentials, can_wait):
 	Raises:
 		RuntimeError: if an error occured upon a request to the GitHub API
 	"""
+	# Inspiration:
+	# https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py
+
 	commits = list()
 
 	page_num = 1

--- a/commitfetch/commitfetch.py
+++ b/commitfetch/commitfetch.py
@@ -81,10 +81,10 @@ def get_repo_commits(repository, credentials, can_wait):
 			user
 		can_wait (bool): If it is set to True and and the GitHub API request
 			rate limit is exceeded for all the user's tokens, the function
-			waits for one hour until it can make more requests
+			waits for one hour until it can make more requests.
 
 	Returns:
-		list: all the commits from the specified repository
+		list: all the commits (Commit) from the specified repository
 
 	Raises:
 		RuntimeError: if an error occured upon a request to the GitHub API

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -43,8 +43,8 @@ def extract_text_lines(file_path, keep_blank_lines):
 def read_reprs(file_path):
 	"""
 	If a text file contains the representation of Python objects, this function
-	can read it to recreate those objects. Each line must contain the string
-	returned by a call to function repr.
+	can read it to recreate those objects. Each line must contain a string
+	returned by function repr.
 
 	This function works only for instances of Commit and objects whose type
 	does not need to be imported.
@@ -68,8 +68,8 @@ def read_reprs(file_path):
 def write_reprs(file_path, objs):
 	"""
 	Writes the representation of Python objects in a text file. Each line
-	contains the string returned by a call to function repr. If the file
-	already exists, this function will overwrite it.
+	contains a string returned by function repr. If the file already exists,
+	this function will overwrite it.
 
 	Args:
 		file_path (str or pathlib.Path): the path to the text file that will

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -18,8 +18,8 @@ def extract_text_lines(file_path, keep_blank_lines):
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file
-		keep_blank_lines (bool): If False, the blank lines will be excluded
-			from this function's output
+		keep_blank_lines (bool): If it is False, the blank lines will be
+			excluded from this function's output
 
 	Returns:
 		list: the lines of text extracted from the specified text file

--- a/commitfetch/github_credentials.py
+++ b/commitfetch/github_credentials.py
@@ -1,12 +1,13 @@
 class GitHubCredentials:
 	"""
-	The credentials consist of a username and a set of tokens owned by the user
-	in question.
+	The credentials consist of a username and tokens owned by the user in
+	question. Methods get_next_token and reset_token_iter facilitate the
+	iteration through the tokens.
 	"""
 
 	def __init__(self, username, tokens):
 		"""
-		The constructor requires a username and a set of tokens.
+		The constructor requires a username and a container of tokens.
 
 		Args:
 			username (str): a GitHub username
@@ -30,7 +31,7 @@ class GitHubCredentials:
 
 		Returns:
 			str: the next unused token
-			None: when all tokens have been used
+			None: if all tokens have been used
 		"""
 		try:
 			token = next(self._token_iter)

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -1,8 +1,8 @@
 """
 This demo shows how this library allows to obtain commit data through the
-GitHub API and store their written representation in a text file. The
-representations are strings returned by a call of function repr on an instance
-of Commit.
+GitHub API and store the written representation of Commit objects in a text
+file. The representations are strings returned by a call of function repr on an
+instance of Commit.
 """
 
 

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -26,7 +26,7 @@ def make_arg_parser():
 		required=True,
 		help="A GitHub repository name in the form <owner>/<name>")
 	parser.add_argument("-t", "--token-file", type=Path, required=True,
-		help="This file must list GitHub tokens owned by -u one by line.")
+		help="This file must list GitHub tokens owned by -u one per line.")
 	parser.add_argument("-u", "--username", type=str, required=True,
 		help="A GitHub username")
 	parser.add_argument("-w", "--can-wait", action="store_true",


### PR DESCRIPTION
* The README describes the library's content and the demos.
* String `token` replaces `tokens` in .gitignore.
* Several corrections were made in the docstrings.