### PR TITLE
Library commitfetch depends on library repr_rw

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ fichier texte, un par ligne.
 Cette fonction est l'élément principal de `commitfetch`. C'est elle qui
 effectue les requêtes à l'API de GitHub pour obtenir les données des commits
 d'un dépôt. Il faut lui fournir des informations d'authentification dans une
-instance de `GitHubCredentials`. La fonction `get_repo_commits` est inspirée de
-la fonction `countfiles` du script
-[CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
+instance de `GitHubCredentials`.
 
 **`read_commit_reprs`**
 
@@ -128,9 +126,7 @@ allows for example to access tokens stored in a text file, one per line.
 
 This function is the main element of `commitfetch`. It performs requests to the
 GitHub API to obtain data about a repository's commits. The user must provide
-their credentials in a `GitHubCredentials` instance. Function
-`get_repo_commits` is based on function `countfiles` from script
-[CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
+their credentials in a `GitHubCredentials` instance.
 
 **`read_commit_reprs`**
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ utilisez les dépôts ci-dessous.
 
 | Dépôt                     | Nombre de commits |
 |---------------------------|:-----------------:|
-| k9mail/k-9                | 10 985            |
-| Skyscanner/backpack       | 7075              |
-| mendhak/gpslogger         | 2239              |
+| k9mail/k-9                | 12 840            |
+| Skyscanner/backpack       | 7788              |
+| mendhak/gpslogger         | 2811              |
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
 
@@ -168,9 +168,9 @@ repositories below.
 
 | Repository                | Number of commits |
 |---------------------------|:-----------------:|
-| k9mail/k-9                | 10 985            |
-| Skyscanner/backpack       | 7075              |
-| mendhak/gpslogger         | 2239              |
+| k9mail/k-9                | 12 840            |
+| Skyscanner/backpack       | 7788              |
+| mendhak/gpslogger         | 2811              |
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ GitHub API. Authentication with GitHub credentials is required.
 
 **`Commit`**
 
-This class contains data of a GitHub commit.
+This class contains data about a GitHub commit.
 
 **`GitHubCredentials`**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # commitfetch
 
-## Français
+## FRANÇAIS
 
 Cette bibliothèque aide à obtenir les données des commits d'un dépôt au moyen
 de l'API de GitHub. L'utilisateur doit fournir ses informations
@@ -97,7 +97,7 @@ Exemple d'exécution:
 python demo_read_commits.py -c scottyab_rootbeer_commits.txt
 ```
 
-## English
+## ENGLISH
 
 This library helps obtaining the data of a repository's commits through the
 GitHub API. Authentication with GitHub credentials is required.

--- a/README.md
+++ b/README.md
@@ -38,19 +38,20 @@ instance de `GitHubCredentials`. La fonction `get_repo_commits` est inspirée de
 la fonction `countfiles` du script
 [CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
 
-**`read_reprs`**
+**`read_commit_reprs`**
 
-Cette fonction lit un fichier texte contenant les représentations d'objets
-Python puis recrée ces objets et les renvoie dans une liste. Les représetations
-sont des chaînes de caractères renvoyées par la fonction `repr`. Chaque ligne
-du fichier doit contenir une représentation.
+Cette fonction lit un fichier texte contenant les représentations d'instances
+de `Commit` puis recrée ces objets et les renvoie dans une liste. Les
+représetations sont des chaînes de caractères renvoyées par la fonction `repr`.
+Chaque ligne du fichier doit être une représentation. Les lignes vides sont
+ignorées.
 
-**`write_reprs`**
+**`write_commit_reprs`**
 
-Cette fonction écrit les représentations d'objets Python dans un fichier texte.
-Les représetations sont des chaînes de caractères renvoyées par la fonction
-`repr`. Chaque ligne du fichier contient une représentation. La fonction
-`read_reprs` peut lire ce fichier.
+Cette fonction écrit les représentations d'instances de `Commit` dans un
+fichier texte. Les représetations sont des chaînes de caractères renvoyées par
+la fonction `repr`. Chaque ligne du fichier est une représentation. La fonction
+`read_commit_reprs` peut lire ce fichier.
 
 ### Démos
 
@@ -131,18 +132,18 @@ their credentials in a `GitHubCredentials` instance. Function
 `get_repo_commits` is based on function `countfiles` from script
 [CollectFiles.py](https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py).
 
-**`read_reprs`**
+**`read_commit_reprs`**
 
-This function reads a text file that contains the representations of Python
-objects then recreates those objects and returns them in a list. The
+This function reads a text file that contains the representations of `Commit`
+instances then recreates those objects and returns them in a list. The
 representations are strings returned by function `repr`. Each line of the file
-must contain one representation.
+must be a representation. Empty lines are ignored.
 
-**`write_reprs`**
+**`write_commit_reprs`**
 
-This function writes the representations of Python objects in a text file. The
-representations are strings returned by function `repr`. Each line of the file
-contains one representation. Function `read_reprs` can read this file.
+This function writes the representations of `Commit` instances in a text file.
+The representations are strings returned by function `repr`. Each line of the
+file is a representation. Function `read_commit_reprs` can read this file.
 
 ### Demos
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,5 +4,5 @@ from .commitfetch import\
 	RepoIdentity,\
 	extract_text_lines,\
 	get_repo_commits,\
-	read_reprs,\
-	write_reprs
+	read_commit_reprs,\
+	write_commit_reprs

--- a/commitfetch/__init__.py
+++ b/commitfetch/__init__.py
@@ -3,9 +3,10 @@ from .commit import\
 	RepoIdentity
 from .commitfetch import\
 	get_repo_commits
+from .commit_rw import\
+	read_commit_reprs,\
+	write_commit_reprs
 from .file_io import\
-	extract_text_lines,\
-	read_reprs,\
-	write_reprs
+	extract_text_lines
 from .github_credentials import\
 	GitHubCredentials

--- a/commitfetch/commit.py
+++ b/commitfetch/commit.py
@@ -33,8 +33,9 @@ class Commit:
 			moment (str or datetime.datetime): the moment when this commit was
 				made. If it is a string, it must match format
 				"%Y-%m-%dT%H:%M:%SZ".
-			files (container): the paths to the files created, modified or
-				deleted in this commit as strings or pathlib.Path objects
+			files (list, set or tuple): the paths to the files created,
+				modified or deleted in this commit as strings or pathlib.Path
+				objects
 
 		Raises:
 			ValueError: if argument repository or moment is a string and does

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -8,18 +8,11 @@ from repr_rw import\
 
 _LOCAL_DIR = Path(__file__).resolve().parent
 _COMMIT_READING_IMPORTATION =\
-	{"from commit import Commit": str(_LOCAL_DIR)}
-print(_COMMIT_READING_IMPORTATION)
+	{"from commit import Commit": _LOCAL_DIR}
 
 
 def read_commit_reprs(file_path):
-	try:
-		commits = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
-	except:
-		exit(1)
-	finally:
-		import sys
-		print(sys.path)
+	commits = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
 	return commits
 
 

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -6,12 +6,21 @@ from repr_rw import\
 	write_reprs
 
 
+_LOCAL_DIR = Path(__file__).resolve().parent
 _COMMIT_READING_IMPORTATION =\
-	{"from commit import Commit": Path(".").resolve()}
+	{"from commit import Commit": str(_LOCAL_DIR)}
+print(_COMMIT_READING_IMPORTATION)
 
 
 def read_commit_reprs(file_path):
-	return read_reprs(file_path, _COMMIT_READING_IMPORTATION)
+	try:
+		commits = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
+	except:
+		exit(1)
+	finally:
+		import sys
+		print(sys.path)
+	return commits
 
 
 def write_commit_reprs(file_path, commits):

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -8,7 +8,6 @@ from repr_rw import\
 
 _COMMIT_READING_IMPORTATION =\
 	{"from commit import Commit": Path(".").resolve()}
-print(_COMMIT_READING_IMPORTATION)
 
 
 def read_commit_reprs(file_path):

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -1,0 +1,30 @@
+from pathlib import\
+	Path
+
+from repr_rw import\
+	read_reprs,\
+	write_reprs
+
+
+_COMMIT_READING_IMPORTATION =\
+	{"from commit import Commit": Path(".").resolve()}
+print(_COMMIT_READING_IMPORTATION)
+
+
+def read_commit_reprs(file_path):
+	return read_reprs(file_path, _COMMIT_READING_IMPORTATION)
+
+
+def write_commit_reprs(file_path, commits):
+	"""
+	Writes the representation of Commit instances in a text file. Each line is
+	a string returned by function repr. If the file already exists, this
+	function will overwrite it.
+
+	Args:
+		file_path (str or pathlib.Path): the path to the text file that will
+			contains the Commit representations
+		objs (list, set or tuple): the Commit instances whose representation
+			will be written
+	"""
+	write_reprs(file_path, commits)

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -12,6 +12,18 @@ _COMMIT_READING_IMPORTATION =\
 
 
 def read_commit_reprs(file_path):
+	"""
+	If a text file contains the representation of Commit instances, this
+	function can read it to recreate those objects. Each line must be a string
+	returned by a call of function repr on a Commit instance.
+
+	Args:
+		file_path (str or pathlib.Path): the path to a text file that contains
+			Commit representations
+
+	Returns:
+		list: the Commit instances recreated from their representation
+	"""
 	commits = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
 	return commits
 
@@ -24,8 +36,8 @@ def write_commit_reprs(file_path, commits):
 
 	Args:
 		file_path (str or pathlib.Path): the path to the text file that will
-			contains the Commit representations
-		objs (list, set or tuple): the Commit instances whose representation
+			contain the Commit representations
+		commits (list, set or tuple): the Commit instances whose representation
 			will be written
 	"""
 	write_reprs(file_path, commits)

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -15,7 +15,8 @@ def read_commit_reprs(file_path):
 	"""
 	If a text file contains the representation of Commit instances, this
 	function can read it to recreate those objects. Each line must be a string
-	returned by a call of function repr on a Commit instance.
+	returned by a call of function repr on a Commit instance. Empty lines are
+	ignored.
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/commitfetch/commitfetch.py
+++ b/commitfetch/commitfetch.py
@@ -89,9 +89,6 @@ def get_repo_commits(repository, credentials, can_wait):
 	Raises:
 		RuntimeError: if an error occured upon a request to the GitHub API
 	"""
-	# Inspiration:
-	# https://github.com/ETS-LOG530/sre/blob/main/sre2021/CollectFiles.py
-
 	commits = list()
 
 	page_num = 1

--- a/commitfetch/commitfetch.py
+++ b/commitfetch/commitfetch.py
@@ -95,7 +95,7 @@ def get_repo_commits(repository, credentials, can_wait):
 	username = credentials.username
 	token = credentials.get_next_token()
 
-	# Loop through all the commit pages until the last returned empty page
+	# Loop through all the commit pages until an empty page is encountered.
 	while True:
 		try:
 			all_commit_data = _request_commit_page(
@@ -107,10 +107,10 @@ def get_repo_commits(repository, credentials, can_wait):
 
 		commit_data_len = len(all_commit_data)
 		if commit_data_len == 0:
-			# Stop the loop if there are no more commits in the pages
+			# Stop the loop if there are no more commits in the pages.
 			break
 
-		# Iterate through the list of commits from the page
+		# Iterate through the list of commits from the page.
 		commit_data_index = 0
 		while commit_data_index < commit_data_len:
 			commit_sha = all_commit_data[commit_data_index][_KEY_SHA]

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -1,13 +1,9 @@
 from pathlib import\
 	Path
 
-from .commit import\
-	Commit
-
 
 _ENCODING_UTF8 = "utf-8"
 _MODE_R = "r"
-_MODE_W = "w"
 _NEW_LINE = "\n"
 
 
@@ -19,7 +15,7 @@ def extract_text_lines(file_path, keep_blank_lines):
 	Args:
 		file_path (str or pathlib.Path): the path to a text file
 		keep_blank_lines (bool): If it is False, the blank lines will be
-			excluded from this function's output
+			excluded from this function's output.
 
 	Returns:
 		list: the lines of text extracted from the specified text file
@@ -38,48 +34,3 @@ def extract_text_lines(file_path, keep_blank_lines):
 	lines = [line for line in raw_lines if len(line) > 0]
 
 	return lines
-
-
-def read_reprs(file_path):
-	"""
-	If a text file contains the representation of Python objects, this function
-	can read it to recreate those objects. Each line must contain a string
-	returned by function repr.
-
-	This function works only for instances of Commit and objects whose type
-	does not need to be imported.
-
-	Args:
-		file_path (str or pathlib.Path): the path to a text file that contains
-			object representations
-
-	Returns:
-		list: the objects recreated from their representation
-	"""
-	objs_reprs = extract_text_lines(file_path, False)
-	objs = list()
-
-	for obj_repr in objs_reprs:
-		objs.append(eval(obj_repr))
-
-	return objs
-
-
-def write_reprs(file_path, objs):
-	"""
-	Writes the representation of Python objects in a text file. Each line
-	contains a string returned by function repr. If the file already exists,
-	this function will overwrite it.
-
-	Args:
-		file_path (str or pathlib.Path): the path to the text file that will
-			contain the object representations
-		objs (container): the objects whose representation will be written
-	"""
-	if isinstance(file_path, str):
-		file_path = Path(file_path)
-
-	with file_path.open(mode=_MODE_W, encoding=_ENCODING_UTF8) as file:
-
-		for obj in objs:
-			file.write(repr(obj) + _NEW_LINE)

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -73,7 +73,7 @@ def write_reprs(file_path, objs):
 
 	Args:
 		file_path (str or pathlib.Path): the path to the text file that will
-			contains the object representations
+			contain the object representations
 		objs (container): the objects whose representation will be written
 	"""
 	if isinstance(file_path, str):

--- a/commitfetch/github_credentials.py
+++ b/commitfetch/github_credentials.py
@@ -11,7 +11,8 @@ class GitHubCredentials:
 
 		Args:
 			username (str): a GitHub username
-			tokens: a container of GitHub tokens (str)
+			tokens (list, set or tuple): GitHub tokens (str) owned by the
+				specified user
 
 		Raises:
 			ValueError: if tokens contains less than one element

--- a/demo_read_commits.py
+++ b/demo_read_commits.py
@@ -11,7 +11,7 @@ from pathlib import\
 	Path
 
 from commitfetch import\
-	read_reprs
+	read_commit_reprs
 
 
 def make_arg_parser():
@@ -27,7 +27,7 @@ parser = make_arg_parser()
 args = parser.parse_args()
 commit_path = args.commit_file
 
-commits = read_reprs(commit_path)
+commits = read_commit_reprs(commit_path)
 
 first_commit = commits[0]
 

--- a/demo_read_commits.py
+++ b/demo_read_commits.py
@@ -1,7 +1,7 @@
 """
 This demo shows how this library allows to read commit representations from a
 text file and convert them to Commit instances. The representations are strings
-returned by a call of function repr on an instance of Commit.
+returned by a call of function repr on a Commit instance.
 """
 
 
@@ -18,7 +18,7 @@ def make_arg_parser():
 	parser = ArgumentParser(description=__doc__)
 	parser.add_argument("-c", "--commit-file", type=Path, required=True,
 		help="Each line of this text file contains a representation"
-			+ " of an instance of Commit.")
+			+ " of a Commit instance.")
 
 	return parser
 

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -16,7 +16,7 @@ from commitfetch import\
 	extract_text_lines,\
 	GitHubCredentials,\
 	RepoIdentity,\
-	write_reprs
+	write_commit_reprs
 
 
 def make_arg_parser():
@@ -46,4 +46,4 @@ tokens = extract_text_lines(token_file, False)
 credentials = GitHubCredentials(username, tokens)
 commits = get_repo_commits(str(repository), credentials, can_wait)
 
-write_reprs(repository.get_full_name("_") + "_commits.txt", commits)
+write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commits)

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -1,8 +1,8 @@
 """
 This demo shows how this library allows to obtain commit data through the
 GitHub API and store the written representation of Commit objects in a text
-file. The representations are strings returned by a call of function repr on an
-instance of Commit.
+file. The representations are strings returned by a call of function repr on a
+Commit instance.
 """
 
 

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -12,10 +12,10 @@ from pathlib import\
 	Path
 
 from commitfetch import\
-	get_repo_commits,\
-	extract_text_lines,\
 	GitHubCredentials,\
 	RepoIdentity,\
+	extract_text_lines,\
+	get_repo_commits,\
 	write_commit_reprs
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+repr_rw==1.0.0
 requests==2.27.1


### PR DESCRIPTION
Functions `write_commit_reprs` and `read_commit_reprs` of library `repr_rw` are responsible for the persistence of commits in text files.