### PR TITLE
Use of generators rather than lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Store your tokens in a text file whose name matches this pattern.
 *token*
 
+# The files created by demo_write_commits.py
+*_commits.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ fichier texte. Les représetations sont des chaînes de caractères renvoyées p
 la fonction `repr`. Chaque ligne du fichier est une représentation. La fonction
 `read_commit_reprs` peut lire ce fichier.
 
-### Démos
+### Dépendances
 
 Exécutez cette commande pour installer les dépendances.
 
 ```
 pip install -r requirements.txt
 ```
+
+### Démos
 
 Consultez les scripts `demo_write_commits.py` et `demo_read_commits.py` dans le
 dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
@@ -144,13 +146,15 @@ This function writes the representations of `Commit` instances in a text file.
 The representations are strings returned by function `repr`. Each line of the
 file is a representation. Function `read_commit_reprs` can read this file.
 
-### Demos
+### Dependencies
 
 Execute this command to install the dependecies.
 
 ```
 pip install -r requirements.txt
 ```
+
+### Demos
 
 See scripts `demo_write_commits.py` and `demo_read_commits.py` in the source
 code repository to know how to use library `commitfetch`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cette classe contient des données d'un commit de GitHub.
 
 Cette classe contient le nom d'un utilisateur de GitHub et des jetons
 d'authentification qu'il possède. Elle aide à effectuer des requêtes
-authentifiées à l'API de GitHub. Chaque jeton permet 2000 requêtes par heure.
+authentifiées à l'API de GitHub. Chaque jeton permet 5000 requêtes par heure.
 
 **`RepoIdentity`**
 
@@ -39,11 +39,11 @@ générateur des informations d'authentification dans une instance de
 
 **`read_commit_reprs`**
 
-Cette fonction lit un fichier texte contenant les représentations d'instances
-de `Commit` puis recrée ces objets et les renvoie dans une liste. Les
-représetations sont des chaînes de caractères renvoyées par la fonction `repr`.
-Chaque ligne du fichier doit être une représentation. Les lignes vides sont
-ignorées.
+Ce générateur lit un fichier texte contenant les représentations d'instances
+de `Commit` et recrée ces objets. Chaque itération produit une instance de
+`Commit`. Les représetations sont des chaînes de caractères renvoyées par la
+fonction `repr`. Chaque ligne du fichier doit être une représentation d'un
+`Commit`. Les lignes vides sont ignorées.
 
 **`write_commit_reprs`**
 
@@ -67,7 +67,7 @@ dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
 leur représentation dans un fichier texte. Il a besoin d'un fichier listant les
 jetons d'authentification de l'utilisateur un par ligne pour effectuer des
 requêtes à l'API GitHub. Pour que ce dépôt ignore les fichiers de jetons, leur
-nom devrait contenir la chaîne «token».
+nom devrait contenir la chaîne «`token`».
 
 Exemple d'exécution:
 
@@ -87,7 +87,7 @@ utilisez les dépôts ci-dessous.
 | scottyab/rootbeer         | 191               |
 
 `demo_read_commits.py` montre comment lire les représentations de commits
-enregistrées par `demo_write_commits.py`. Pour confirmer que la lecture a
+enregistrées dans un fichier texte. Pour confirmer que la lecture a
 fonctionné, il affiche les données d'un commit dans la console.
 
 Exemple d'exécution:
@@ -111,7 +111,7 @@ This class contains data about a GitHub commit.
 
 This class contains the name of a GitHub user and authentication tokens that
 they own. It helps making authenticated requests to the GitHub API. Each token
-allows 2000 requests per hour.
+allows 5000 requests per hour.
 
 **`RepoIdentity`**
 
@@ -133,10 +133,10 @@ yields a `Commit` instance. The user must provide their credentials in a
 
 **`read_commit_reprs`**
 
-This function reads a text file that contains the representations of `Commit`
-instances then recreates those objects and returns them in a list. The
-representations are strings returned by function `repr`. Each line of the file
-must be a representation. Empty lines are ignored.
+This generator reads a text file that contains the representations of `Commit`
+instances and recreates those objects. Each iteration yields a `Commit`
+instance. The representations are strings returned by function `repr`. Each
+line in the file must be a `Commit` representation. Empty lines are ignored.
 
 **`write_commit_reprs`**
 
@@ -159,7 +159,7 @@ code repository to know how to use library `commitfetch`.
 representation in a text file. It needs a file that lists the user's
 authentication tokens one per line to perform requests to the GitHub API. This
 repository will ignore the token files if their name contains the string
-"token".
+"`token`".
 
 Execution example:
 
@@ -177,9 +177,9 @@ repositories below.
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
 
-`demo_read_commits.py` shows how to read the commit representations recorded by
-`demo_write_commits.py`. It confirms that the reading was successful by
-displaying a commit's data in the console.
+`demo_read_commits.py` shows how to read the commit representations recorded
+in a text file. It confirms that the reading was successful by displaying a
+commit's data in the console.
 
 Execution example:
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ pip install -r requirements.txt
 Consultez les scripts `demo_write_commits.py` et `demo_read_commits.py` dans le
 dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
 
-`demo_write_commits.py` obtient les commits d'un dépôt GitHub et enregistre
-leur représentation dans un fichier texte. Il a besoin d'un fichier listant les
+#### Enregistrer des commits
+
+`demo_write_commits.py` obtient les commits d'un dépôt GitHub et écrit leur
+représentation dans un fichier texte. Il a besoin d'un fichier listant les
 jetons d'authentification de l'utilisateur un par ligne pour effectuer des
 requêtes à l'API GitHub. Pour que ce dépôt ignore les fichiers de jetons, leur
 nom devrait contenir la chaîne «`token`».
@@ -87,6 +89,8 @@ utilisez les dépôts ci-dessous.
 | mendhak/gpslogger         | 2811              |
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
+
+#### Lire des commits
 
 `demo_read_commits.py` montre comment lire les représentations de commits
 enregistrées dans un fichier texte. Pour confirmer que la lecture a
@@ -159,6 +163,8 @@ pip install -r requirements.txt
 See scripts `demo_write_commits.py` and `demo_read_commits.py` in the source
 code repository to know how to use library `commitfetch`.
 
+#### Recording commits
+
 `demo_write_commits.py` obtains a GitHub repository's commits and writes their
 representation in a text file. It needs a file that lists the user's
 authentication tokens one per line to perform requests to the GitHub API. This
@@ -180,6 +186,8 @@ repositories below.
 | mendhak/gpslogger         | 2811              |
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
+
+#### Reading commits
 
 `demo_read_commits.py` shows how to read the commit representations recorded
 in a text file. It confirms that the reading was successful by displaying a

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip install -r requirements.txt
 Consultez les scripts `demo_write_commits.py` et `demo_read_commits.py` dans le
 dépôt de code pour savoir comment utiliser la bibliothèque `commitfetch`.
 
-#### Enregistrer des commits
+#### Enregistrement des commits
 
 `demo_write_commits.py` obtient les commits d'un dépôt GitHub et écrit leur
 représentation dans un fichier texte. Il a besoin d'un fichier listant les
@@ -90,7 +90,7 @@ utilisez les dépôts ci-dessous.
 | PeterIJia/android_xlight  | 397               |
 | scottyab/rootbeer         | 191               |
 
-#### Lire des commits
+#### Lecture des commits
 
 `demo_read_commits.py` montre comment lire les représentations de commits
 enregistrées dans un fichier texte. Pour confirmer que la lecture a

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ du dépôt. L'identité est souvent écrite sous le format `propriétaire`/`nom`
 
 **`extract_text_lines`**
 
-Cette fonction lit le fichier texte spécifié et renvoie ses lignes dans une
-liste. Elle permet par exemple d'accéder à des jetons enregistrés dans un
-fichier texte, un par ligne.
+Ce générateur lit le fichier texte spécifié et renvoie une de ses lignes à
+chaque itération. Il permet par exemple d'accéder à des jetons enregistrés
+dans un fichier texte, un par ligne.
 
 **`get_repo_commits`**
 
@@ -120,8 +120,9 @@ repository's name. The identity is often written in the format `owner`/`name`.
 
 **`extract_text_lines`**
 
-This function reads the specified text file and returns its lines in a list. It
-allows for example to access tokens stored in a text file, one per line.
+This generator reads the specified text file and yields one of its lines at
+each iteration. It allows for example to access tokens stored in a text file,
+one per line.
 
 **`get_repo_commits`**
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ fichier texte, un par ligne.
 
 **`get_repo_commits`**
 
-Cette fonction est l'élément principal de `commitfetch`. C'est elle qui
-effectue les requêtes à l'API de GitHub pour obtenir les données des commits
-d'un dépôt. Il faut lui fournir des informations d'authentification dans une
-instance de `GitHubCredentials`.
+Ce générateur est l'élément principal de `commitfetch`. C'est lui qui effectue
+les requêtes à l'API de GitHub pour obtenir les données des commits d'un dépôt.
+Chaque iteration produit une instance de `Commit`. Il faut fournir à ce
+générateur des informations d'authentification dans une instance de
+`GitHubCredentials`.
 
 **`read_commit_reprs`**
 
@@ -124,9 +125,10 @@ allows for example to access tokens stored in a text file, one per line.
 
 **`get_repo_commits`**
 
-This function is the main element of `commitfetch`. It performs requests to the
-GitHub API to obtain data about a repository's commits. The user must provide
-their credentials in a `GitHubCredentials` instance.
+This generator is the core element of `commitfetch`. It performs requests to
+the GitHub API to obtain data about a repository's commits. Each iteration
+yields a `Commit` instance. The user must provide their credentials in a
+`GitHubCredentials` instance.
 
 **`read_commit_reprs`**
 

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -14,19 +14,23 @@ _COMMIT_READING_IMPORTATION =\
 def read_commit_reprs(file_path):
 	"""
 	If a text file contains the representation of Commit instances, this
-	function can read it to recreate those objects. Each line must be a string
+	generator can read it to recreate those objects. Each line must be a string
 	returned by a call of function repr on a Commit instance. Empty lines are
-	ignored.
+	ignored. Each iteration yields a Commit instance.
 
-	Args:
+	Parameters:
 		file_path (str or pathlib.Path): the path to a text file that contains
-			Commit representations
+			Commit representations.
 
-	Returns:
-		list: the Commit instances recreated from their representation
+	Yields:
+		Commit: the Commit instances recreated from their representation.
+
+	Raises:
+		FileNotFoundError: if argument file_path does not exist.
+		TypeError: if argument file_path is not of type str or pathlib.Path.
 	"""
-	commits = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
-	return commits
+	commit_generator = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
+	return commit_generator
 
 
 def write_commit_reprs(file_path, commits):
@@ -35,7 +39,7 @@ def write_commit_reprs(file_path, commits):
 	a string returned by function repr. If the file already exists, this
 	function will overwrite it.
 
-	Args:
+	Parameters:
 		file_path (str or pathlib.Path): the path to the text file that will
 			contain the Commit representations
 		commits (generator, list, set or tuple): the Commit instances whose

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -38,7 +38,7 @@ def write_commit_reprs(file_path, commits):
 	Args:
 		file_path (str or pathlib.Path): the path to the text file that will
 			contain the Commit representations
-		commits (list, set or tuple): the Commit instances whose representation
-			will be written
+		commits (generator, list, set or tuple): the Commit instances whose
+			representation will be written
 	"""
 	write_reprs(file_path, commits)

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -13,17 +13,18 @@ _COMMIT_READING_IMPORTATION =\
 
 def read_commit_reprs(file_path):
 	"""
-	If a text file contains the representation of Commit instances, this
-	generator can read it to recreate those objects. Each line must be a string
-	returned by a call of function repr on a Commit instance. Empty lines are
-	ignored. Each iteration yields a Commit instance.
+	This generator reads a text file that contains the representations of
+	Commit instances and recreates those objects. Each iteration yields a
+	Commit instance. The representations are strings returned by function
+	repr. Each line in the file must be a Commit representation. Empty lines
+	are ignored.
 
 	Parameters:
 		file_path (str or pathlib.Path): the path to a text file that contains
 			Commit representations.
 
 	Yields:
-		Commit: the Commit instances recreated from their representation.
+		Commit: a Commit instance recreated from its representation.
 
 	Raises:
 		FileNotFoundError: if argument file_path does not exist.

--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -29,6 +29,8 @@ def read_commit_reprs(file_path):
 	Raises:
 		FileNotFoundError: if argument file_path does not exist.
 		TypeError: if argument file_path is not of type str or pathlib.Path.
+		Exception: any exception raised upon the parsing of a Commit
+			representation.
 	"""
 	commit_generator = read_reprs(file_path, _COMMIT_READING_IMPORTATION)
 	return commit_generator

--- a/commitfetch/commitfetch.py
+++ b/commitfetch/commitfetch.py
@@ -72,25 +72,24 @@ def _commit_from_api_data(commit_data):
 
 def get_repo_commits(repository, credentials, can_wait):
 	"""
-	Obtains data about all the commits in a GitHub repository through the
-	GitHub API.
+	This generator obtains data about all the commits in a GitHub repository
+	through the GitHub API. Each iteration yields data about one commit.
 
-	Args:
-		repository (str): a repository's full name in the format <owner>/<name>
+	Parameters:
+		repository (str): a repository's full name in the format
+			<owner>/<name>.
 		credentials (GitHubCredentials): the username and tokens of a GitHub
-			user
+			user.
 		can_wait (bool): If it is set to True and and the GitHub API request
 			rate limit is exceeded for all the user's tokens, the function
 			waits for one hour until it can make more requests.
 
-	Returns:
-		list: all the commits (Commit) from the specified repository
+	Yields:
+		Commit: data about one commit from the specified repository.
 
 	Raises:
-		RuntimeError: if an error occured upon a request to the GitHub API
+		RuntimeError: if an error occured upon a request to the GitHub API.
 	"""
-	commits = list()
-
 	page_num = 1
 	username = credentials.username
 	token = credentials.get_next_token()
@@ -117,18 +116,15 @@ def get_repo_commits(repository, credentials, can_wait):
 
 			try:
 				commit = _request_commit(commit_sha, repository, username, token)
-				commits.append(commit)
+				yield commit
 
 			except RuntimeError as rte:
 				token = _catch_github_api_exception(rte, credentials, can_wait)
-
 				continue
 
 			commit_data_index += 1
 
 		page_num += 1
-
-	return commits
 
 
 def _raise_github_api_exception(api_data):
@@ -142,7 +138,7 @@ def _raise_github_api_exception(api_data):
 
 def _repo_from_commit_api_url(url):
 	path_commits_index = url.index(_PATH_COMMITS)
-	repo_full_name =  url[_PATH_REPOS_LEN:path_commits_index]
+	repo_full_name =  url[_PATH_REPOS_LEN: path_commits_index]
 	return RepoIdentity.from_full_name(repo_full_name)
 
 
@@ -150,7 +146,7 @@ def _request_commit(commit_sha, repository, username, token):
 	"""
 	Requests a commit from the GitHub API.
 
-	Args:
+	Parameters:
 		commit_sha (str): a SHA hash that identifies a commit
 		repository (str): a GitHub repository name in the format <owner>/<name>
 		username (str): a GitHub username
@@ -176,7 +172,7 @@ def _request_commit_page(repository, page_num, username, token):
 	"""
 	Requests a page of commit data from the GitHub API.
 
-	Args:
+	Parameters:
 		repository (str): a GitHub repository name in the format <owner>/<name>
 		page_num (int): the number of a commit page on the GitHub API, >= 1
 		username (str): a GitHub username

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -44,5 +44,6 @@ def extract_text_lines(file_path, keep_blank_lines):
 
 	with file_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as file:
 		for line in file:
+			line = line.strip() # Remove '\n' at the end.
 			if is_line_accepted(line):
 				yield line

--- a/commitfetch/file_io.py
+++ b/commitfetch/file_io.py
@@ -4,33 +4,45 @@ from pathlib import\
 
 _ENCODING_UTF8 = "utf-8"
 _MODE_R = "r"
-_NEW_LINE = "\n"
+
+
+def _ensure_is_path(obj):
+	if isinstance(obj, Path):
+		return obj
+
+	elif isinstance(obj, str):
+		return Path(obj)
+
+	else:
+		raise TypeError(
+			"An argument of type str or pathlib.Path is expected.")
 
 
 def extract_text_lines(file_path, keep_blank_lines):
 	"""
-	Reads a text file and extracts its content as separate lines rather than a
-	single string.
+	This generator reads a text file and extracts its content as separate lines
+	rather than a single string. Each iteration yields one line.
 
-	Args:
-		file_path (str or pathlib.Path): the path to a text file
+	Parameters:
+		file_path (str or pathlib.Path): the path to a text file.
 		keep_blank_lines (bool): If it is False, the blank lines will be
 			excluded from this function's output.
 
-	Returns:
-		list: the lines of text extracted from the specified text file
+	Yields:
+		str: a line of text extracted from the specified text file.
+
+	Raises:
+		FileNotFoundError: if argument file_path does not exist.
+		TypeError: if argument file_path is not of type str or pathlib.Path.
 	"""
-	if isinstance(file_path, str):
-		file_path = Path(file_path)
-
-	with file_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as file:
-		text = file.read()
-
-	raw_lines = text.split(_NEW_LINE)
+	file_path = _ensure_is_path(file_path)
 
 	if keep_blank_lines:
-		return raw_lines
+		is_line_accepted = lambda line: True
+	else:
+		is_line_accepted = lambda line: len(line) > 0
 
-	lines = [line for line in raw_lines if len(line) > 0]
-
-	return lines
+	with file_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as file:
+		for line in file:
+			if is_line_accepted(line):
+				yield line

--- a/commitfetch/github_credentials.py
+++ b/commitfetch/github_credentials.py
@@ -9,19 +9,19 @@ class GitHubCredentials:
 		"""
 		The constructor requires a username and a container of tokens.
 
-		Args:
-			username (str): a GitHub username
-			tokens (list, set or tuple): GitHub tokens (str) owned by the
-				specified user
+		Parameters:
+			username (str): a GitHub username.
+			tokens (generator, list, set or tuple): GitHub tokens (str) owned
+				by the specified user.
 
 		Raises:
-			ValueError: if tokens contains less than one element
+			ValueError: if argument tokens contains less than one element.
 		"""
-		if len(tokens) < 1:
-			raise ValueError("At least one token must be provided.")
-
 		self._username = username
 		self._tokens = tuple(tokens)
+		if len(self._tokens) < 1:
+			raise ValueError("At least one token must be provided.")
+
 		self.reset_token_iter()
 
 	def get_next_token(self):
@@ -31,8 +31,8 @@ class GitHubCredentials:
 		method allows to obtain the next unused token stored here.
 
 		Returns:
-			str: the next unused token
-			None: if all tokens have been used
+			str: the next unused token.
+			None: if all tokens have been used.
 		"""
 		try:
 			token = next(self._token_iter)
@@ -50,13 +50,13 @@ class GitHubCredentials:
 	@property
 	def tokens(self):
 		"""
-		tuple: tokens (str) owned by this GitHub user
+		tuple: tokens (str) owned by this GitHub user.
 		"""
 		return self._tokens
 
 	@property
 	def username(self):
 		"""
-		str: this GitHub user's name
+		str: this GitHub user's name.
 		"""
 		return self._username

--- a/demo_read_commits.py
+++ b/demo_read_commits.py
@@ -27,9 +27,9 @@ parser = make_arg_parser()
 args = parser.parse_args()
 commit_path = args.commit_file
 
-commits = read_commit_reprs(commit_path)
+commit_generator = read_commit_reprs(commit_path)
 
-first_commit = commits[0]
+first_commit = next(commit_generator)
 
 print("First commit")
 print(f"SHA: {first_commit.sha}")

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -44,6 +44,6 @@ can_wait = args.can_wait
 
 tokens = extract_text_lines(token_file, False)
 credentials = GitHubCredentials(username, tokens)
-commits = get_repo_commits(str(repository), credentials, can_wait)
+commit_generator = get_repo_commits(str(repository), credentials, can_wait)
 
-write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commits)
+write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)

--- a/demo_write_commits.py
+++ b/demo_write_commits.py
@@ -42,8 +42,8 @@ token_file = args.token_file
 username = args.username
 can_wait = args.can_wait
 
-tokens = extract_text_lines(token_file, False)
-credentials = GitHubCredentials(username, tokens)
+token_generator = extract_text_lines(token_file, False)
+credentials = GitHubCredentials(username, token_generator)
 commit_generator = get_repo_commits(str(repository), credentials, can_wait)
 
 write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-repr_rw==1.0.4
+repr_rw==1.0.6
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-repr_rw==1.0.6
+repr_rw==2.0.0
 requests==2.27.1


### PR DESCRIPTION
* The following functions have become generators.
  * `extract_text_lines`
  * `get_repo_commits`
  * `read_commit_reprs`
* Library `repr_rw` was upgraded to version `2.0.0`, which uses generators.
* `README.md`: distinct sections for the dependencies and the demos.