### PR TITLE
Writing demo execution time

### DIFF
--- a/demos/demo_write_commits.py
+++ b/demos/demo_write_commits.py
@@ -62,4 +62,4 @@ try:
 finally:
 	end_moment = dt_now()
 	exec_time = end_moment - start_moment
-	print(f"Execution time: {exec_time.seconds}.{exec_time.microseconds} seconds")
+	print(f"Execution time: {exec_time.total_seconds()} seconds")

--- a/demos/demo_write_commits.py
+++ b/demos/demo_write_commits.py
@@ -56,9 +56,10 @@ credentials = GitHubCredentials(username, token_generator)
 commit_generator = get_repo_commits(str(repository), credentials, can_wait)
 
 dt_now = datetime.now
+commit_file_path = repository.get_full_name("_") + "_commits.txt"
 try:
 	start_moment = dt_now()
-	write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)
+	write_commit_reprs(commit_file_path, commit_generator)
 finally:
 	end_moment = dt_now()
 	exec_time = end_moment - start_moment

--- a/demos/demo_write_commits.py
+++ b/demos/demo_write_commits.py
@@ -63,4 +63,4 @@ try:
 finally:
 	end_moment = dt_now()
 	exec_time = end_moment - start_moment
-	print(f"Execution time: {exec_time.total_seconds()} seconds")
+	print(f"Execution time: {exec_time} ({exec_time.total_seconds()} seconds)")

--- a/demos/demo_write_commits.py
+++ b/demos/demo_write_commits.py
@@ -61,4 +61,5 @@ try:
 	write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)
 finally:
 	end_moment = dt_now()
-	print(f"Execution time: {end_moment - start_moment}")
+	exec_time = end_moment - start_moment
+	print(f"Execution time: {exec_time.seconds}.{exec_time.microseconds} seconds")

--- a/demos/demo_write_commits.py
+++ b/demos/demo_write_commits.py
@@ -8,6 +8,8 @@ Commit instance.
 
 from argparse import\
 	ArgumentParser
+from datetime import\
+	datetime
 from pathlib import\
 	Path
 
@@ -53,4 +55,10 @@ token_generator = extract_text_lines(token_file, False)
 credentials = GitHubCredentials(username, token_generator)
 commit_generator = get_repo_commits(str(repository), credentials, can_wait)
 
-write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)
+dt_now = datetime.now
+try:
+	start_moment = dt_now()
+	write_commit_reprs(repository.get_full_name("_") + "_commits.txt", commit_generator)
+finally:
+	end_moment = dt_now()
+	print(f"Execution time: {end_moment - start_moment}")


### PR DESCRIPTION
Script `demos/demo_write_commits.py` displays the time it took to write all the `Commit` representations.