### PR TITLE
Commit author not found

### DIFF
--- a/commitfetch/commit_requests.py
+++ b/commitfetch/commit_requests.py
@@ -159,14 +159,14 @@ def _make_commit_from_api_data(commit_data, username, token):
 	author = None
 	author_login, author_id = _get_commit_author_login_and_id(commit_data)
 
-	try:
-		if author_login is not None:
+	if author_login is not None:
+		try:
 			author = _request_github_user(author_login, username, token)
-	except GitHubAPIError as ghae:
-		if ghae.status != _STATUS_404:
-			raise
+		except GitHubAPIError as ghae:
+			if ghae.status != _STATUS_404:
+				raise
 
-		author = GitHubUser(author_id, author_login, None)
+			author = GitHubUser(author_id, author_login, None)
 
 	file_data = commit_data[_KEY_FILES]
 	file_generator = (fd[_KEY_FILENAME] for fd in file_data)

--- a/commitfetch/commit_requests.py
+++ b/commitfetch/commit_requests.py
@@ -74,14 +74,14 @@ def _get_commit_author_login_and_id(commit_data):
 
 	author_struct = commit_data[_KEY_AUTHOR]
 	if author_struct is not None:
-		author_login = author_struct[_KEY_LOGIN]
-		author_id = author_struct[_KEY_ID]
+		author_login = author_struct.get(_KEY_LOGIN)
+		author_id = author_struct.get(_KEY_ID)
 
 	if author_login is None:
 		committer_struct = commit_data[_KEY_COMMITTER]
 		if committer_struct is not None:
-			author_login = committer_struct[_KEY_LOGIN]
-			author_id = committer_struct[_KEY_ID]
+			author_login = committer_struct.get(_KEY_LOGIN)
+			author_id = committer_struct.get(_KEY_ID)
 
 	return author_login, author_id
 

--- a/commitfetch/github_data/github_user.py
+++ b/commitfetch/github_data/github_user.py
@@ -21,7 +21,7 @@ class GitHubUser:
 
 	def __repr__(self):
 		return self.__class__.__name__\
-			+ f"({self._id}, '{self._login}', '{self._name}')"
+			+ f"({repr(self._id)}, {repr(self._login)}, {repr(self._name)})"
 
 	def __eq__(self, value):
 		if not isinstance(value, GitHubUser):


### PR DESCRIPTION
If a commit's author is not found in the GitHub API, their login name and ID are obtained from object `author` or `committer` in the commit's data. If both objects are `null`/`None`, the commit's author is `None`.

Pull requests #20 and #21 helped solving the issue of missing authors.