### PR TITLE
`repr_rw` version updated to `3.0.3`

### DIFF
--- a/commitfetch/commit_rw.py
+++ b/commitfetch/commit_rw.py
@@ -1,6 +1,8 @@
 # __all__ declared at the module's end
 
-import sys
+# syspathmodif is a dependency of repr_rw.
+from syspathmodif import\
+	sm_contains
 
 from repr_rw import\
 	read_reprs,\
@@ -55,7 +57,7 @@ def read_commit_reprs(file_path):
 	# been imported at least once and thus, included in sys.modules. This makes
 	# commitfetch available for import with no modifications to sys.path.
 
-	if _LIB_NAME not in sys.modules:
+	if not sm_contains(_LIB_NAME):
 		_add_lib_to_sys_modules()
 
 	commit_generator = read_reprs(file_path, _COMMIT_READING_IMPORTATIONS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-repr_rw==3.0.2
+repr_rw==3.0.3
 requests==2.32.3


### PR DESCRIPTION
`commit_rw.read_commit_reprs` calls `syspathmodif.sm_contains`. `commit_rw` does not import module `sys`.